### PR TITLE
videresender response som inkluderer headere

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <java.version>14</java.version>
 
     <!-- dependent versions other than from spring-boot -->
-    <bidrag-commons.version>0.3.7</bidrag-commons.version>
+    <bidrag-commons.version>0.4.0</bidrag-commons.version>
     <bidrag-commons-test.version>0.2.1</bidrag-commons-test.version>
     <bidrag-dokument-dto.version>0.10.1</bidrag-dokument-dto.version>
     <logback.encoder.version>6.4</logback.encoder.version>

--- a/src/main/java/no/nav/bidrag/dokument/consumer/BidragArkivConsumer.java
+++ b/src/main/java/no/nav/bidrag/dokument/consumer/BidragArkivConsumer.java
@@ -3,7 +3,7 @@ package no.nav.bidrag.dokument.consumer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import no.nav.bidrag.commons.web.HttpStatusResponse;
+import no.nav.bidrag.commons.web.HttpResponse;
 import no.nav.bidrag.dokument.dto.JournalpostDto;
 import no.nav.bidrag.dokument.dto.JournalpostResponse;
 import org.slf4j.Logger;
@@ -27,7 +27,7 @@ public class BidragArkivConsumer {
     this.restTemplate = restTemplate;
   }
 
-  public HttpStatusResponse<JournalpostResponse> hentJournalpost(String saksnummer, String id) {
+  public HttpResponse<JournalpostResponse> hentJournalpost(String saksnummer, String id) {
     String url;
 
     if (saksnummer == null) {
@@ -40,7 +40,7 @@ public class BidragArkivConsumer {
 
     LOGGER.info("Hent journalpost fikk http status {} fra bidrag-dokument-arkiv", journalpostExchange.getStatusCode());
 
-    return new HttpStatusResponse<>(journalpostExchange.getStatusCode(), journalpostExchange.getBody());
+    return new HttpResponse<>(journalpostExchange);
   }
 
   public List<JournalpostDto> finnJournalposter(String saksnummer, String fagomrade) {

--- a/src/main/java/no/nav/bidrag/dokument/consumer/BidragJournalpostConsumer.java
+++ b/src/main/java/no/nav/bidrag/dokument/consumer/BidragJournalpostConsumer.java
@@ -5,7 +5,7 @@ import static no.nav.bidrag.commons.web.EnhetFilter.X_ENHET_HEADER;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import no.nav.bidrag.commons.web.HttpStatusResponse;
+import no.nav.bidrag.commons.web.HttpResponse;
 import no.nav.bidrag.dokument.dto.AvvikType;
 import no.nav.bidrag.dokument.dto.Avvikshendelse;
 import no.nav.bidrag.dokument.dto.EndreJournalpostCommand;
@@ -56,7 +56,7 @@ public class BidragJournalpostConsumer {
     };
   }
 
-  public HttpStatusResponse<JournalpostResponse> hentJournalpostResponse(String saksnummer, String id) {
+  public HttpResponse<JournalpostResponse> hentJournalpostResponse(String saksnummer, String id) {
     String path;
 
     if (saksnummer != null) {
@@ -69,10 +69,10 @@ public class BidragJournalpostConsumer {
     var exchange = restTemplate.exchange(path, HttpMethod.GET, null, JournalpostResponse.class);
 
     LOGGER.info("Hent journalpost fikk http status {} fra bidrag-dokument-journalpost", exchange.getStatusCode());
-    return new HttpStatusResponse<>(exchange.getStatusCode(), exchange.getBody());
+    return new HttpResponse<>(exchange);
   }
 
-  public HttpStatusResponse<Void> endre(String enhet, EndreJournalpostCommand endreJournalpostCommand) {
+  public HttpResponse<Void> endre(String enhet, EndreJournalpostCommand endreJournalpostCommand) {
     var path = String.format(PATH_JOURNALPOST_UTEN_SAK, endreJournalpostCommand.getJournalpostId());
     LOGGER.info("Endre journalpost BidragDokument: {}, path {}", endreJournalpostCommand, path);
 
@@ -81,10 +81,10 @@ public class BidragJournalpostConsumer {
     );
 
     LOGGER.info("Endre journalpost fikk http status {}", endretJournalpostResponse.getStatusCode());
-    return new HttpStatusResponse<>(endretJournalpostResponse.getStatusCode());
+    return new HttpResponse<>(endretJournalpostResponse);
   }
 
-  public HttpStatusResponse<List<AvvikType>> finnAvvik(String saksnummer, String journalpostId) {
+  public HttpResponse<List<AvvikType>> finnAvvik(String saksnummer, String journalpostId) {
     String path;
 
     if (saksnummer != null) {
@@ -96,7 +96,7 @@ public class BidragJournalpostConsumer {
     LOGGER.info("Finner avvik på journalpost fra bidrag-dokument-journalpost{}", path);
 
     var avviksResponse = restTemplate.exchange(path, HttpMethod.GET, null, typereferansenErListeMedAvvikstyper());
-    return new HttpStatusResponse<>(avviksResponse.getStatusCode(), avviksResponse.getBody());
+    return new HttpResponse<>(avviksResponse);
   }
 
   private ParameterizedTypeReference<List<AvvikType>> typereferansenErListeMedAvvikstyper() {
@@ -104,7 +104,7 @@ public class BidragJournalpostConsumer {
     };
   }
 
-  public HttpStatusResponse<OpprettAvvikshendelseResponse> opprettAvvik(String enhetsnummer, String journalpostId, Avvikshendelse avvikshendelse) {
+  public HttpResponse<OpprettAvvikshendelseResponse> opprettAvvik(String enhetsnummer, String journalpostId, Avvikshendelse avvikshendelse) {
     var path = String.format(PATH_JOURNALPOST_UTEN_SAK + "/avvik", journalpostId);
     LOGGER.info("bidrag-dokument-journalpost{}: {}", path, avvikshendelse);
 
@@ -112,7 +112,7 @@ public class BidragJournalpostConsumer {
         path, HttpMethod.POST, new HttpEntity<>(avvikshendelse, createEnhetHeader(enhetsnummer)), OpprettAvvikshendelseResponse.class
     );
 
-    return new HttpStatusResponse<>(avviksResponse.getStatusCode(), avviksResponse.getBody());
+    return new HttpResponse<>(avviksResponse);
   }
 
   public static HttpHeaders createEnhetHeader(String enhet) {

--- a/src/main/java/no/nav/bidrag/dokument/service/JournalpostService.java
+++ b/src/main/java/no/nav/bidrag/dokument/service/JournalpostService.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import no.nav.bidrag.commons.KildesystemIdenfikator;
-import no.nav.bidrag.commons.web.HttpStatusResponse;
+import no.nav.bidrag.commons.web.HttpResponse;
 import no.nav.bidrag.dokument.consumer.BidragArkivConsumer;
 import no.nav.bidrag.dokument.consumer.BidragJournalpostConsumer;
 import no.nav.bidrag.dokument.dto.AvvikType;
@@ -32,7 +32,7 @@ public class JournalpostService {
     this.bidragJournalpostConsumer = bidragJournalpostConsumer;
   }
 
-  public HttpStatusResponse<JournalpostResponse> hentJournalpost(String saksnummer, KildesystemIdenfikator kildesystemIdenfikator) {
+  public HttpResponse<JournalpostResponse> hentJournalpost(String saksnummer, KildesystemIdenfikator kildesystemIdenfikator) {
     if (kildesystemIdenfikator.erFor(BIDRAG)) {
       return bidragJournalpostConsumer.hentJournalpostResponse(saksnummer, kildesystemIdenfikator.getPrefiksetJournalpostId());
     }
@@ -40,22 +40,22 @@ public class JournalpostService {
     return bidragArkivConsumer.hentJournalpost(saksnummer, kildesystemIdenfikator.getPrefiksetJournalpostId());
   }
 
-  public HttpStatusResponse<List<AvvikType>> finnAvvik(String saksnummer, KildesystemIdenfikator kildesystemIdenfikator) {
+  public HttpResponse<List<AvvikType>> finnAvvik(String saksnummer, KildesystemIdenfikator kildesystemIdenfikator) {
     if (kildesystemIdenfikator.erFor(BIDRAG)) {
       return bidragJournalpostConsumer.finnAvvik(saksnummer, kildesystemIdenfikator.getPrefiksetJournalpostId());
     }
 
-    return new HttpStatusResponse<>(HttpStatus.BAD_REQUEST, Collections.emptyList());
+    return HttpResponse.from(HttpStatus.BAD_REQUEST, Collections.emptyList());
   }
 
-  public HttpStatusResponse<OpprettAvvikshendelseResponse> opprettAvvik(
+  public HttpResponse<OpprettAvvikshendelseResponse> opprettAvvik(
       String enhet, KildesystemIdenfikator kildesystemIdenfikator, Avvikshendelse avvikshendelse
   ) {
     if (kildesystemIdenfikator.erFor(BIDRAG)) {
       return bidragJournalpostConsumer.opprettAvvik(enhet, kildesystemIdenfikator.getPrefiksetJournalpostId(), avvikshendelse);
     }
 
-    return new HttpStatusResponse<>(HttpStatus.BAD_REQUEST);
+    return HttpResponse.from(HttpStatus.BAD_REQUEST);
   }
 
   public List<JournalpostDto> finnJournalposter(String saksnummer, String fagomrade) {
@@ -65,7 +65,7 @@ public class JournalpostService {
     return sakjournal;
   }
 
-  public HttpStatusResponse<Void> endre(String enhet, EndreJournalpostCommand endreJournalpostCommand) {
+  public HttpResponse<Void> endre(String enhet, EndreJournalpostCommand endreJournalpostCommand) {
     return bidragJournalpostConsumer.endre(enhet, endreJournalpostCommand);
   }
 }

--- a/src/test/java/no/nav/bidrag/dokument/CorrelationIdFilterTest.java
+++ b/src/test/java/no/nav/bidrag/dokument/CorrelationIdFilterTest.java
@@ -14,7 +14,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import java.util.stream.Collectors;
 import no.nav.bidrag.commons.KildesystemIdenfikator;
-import no.nav.bidrag.commons.web.HttpStatusResponse;
+import no.nav.bidrag.commons.web.HttpResponse;
 import no.nav.bidrag.commons.web.test.HttpHeaderTestRestTemplate;
 import no.nav.bidrag.dokument.dto.JournalpostResponse;
 import no.nav.bidrag.dokument.service.JournalpostService;
@@ -64,7 +64,7 @@ class CorrelationIdFilterTest {
   @DisplayName("skal logge requests mot applikasjonen")
   void skalLoggeRequestsMotApplikasjonen() {
     when(journalpostServiceMock.hentJournalpost(anyString(), any(KildesystemIdenfikator.class)))
-        .thenReturn(new HttpStatusResponse<>(HttpStatus.I_AM_A_TEAPOT));
+        .thenReturn(HttpResponse.from(HttpStatus.I_AM_A_TEAPOT));
 
     var response = securedTestRestTemplate.exchange(
         "http://localhost:" + port + "/bidrag-dokument/journal/BID-123?saksnummer=777",

--- a/src/test/java/no/nav/bidrag/dokument/EnhetFilterFilterTest.java
+++ b/src/test/java/no/nav/bidrag/dokument/EnhetFilterFilterTest.java
@@ -15,7 +15,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import java.util.stream.Collectors;
 import no.nav.bidrag.commons.KildesystemIdenfikator;
-import no.nav.bidrag.commons.web.HttpStatusResponse;
+import no.nav.bidrag.commons.web.HttpResponse;
 import no.nav.bidrag.commons.web.test.HttpHeaderTestRestTemplate;
 import no.nav.bidrag.dokument.service.JournalpostService;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,7 +65,7 @@ class EnhetFilterFilterTest {
   @DisplayName("skal logge requests mot applikasjonen som ikke inneholder enhetsinformasjon i header")
   void skalLoggeRequestsMotApplikasjonenUtenHeaderInformasjon() {
     when(journalpostServiceMock.hentJournalpost(anyString(), any(KildesystemIdenfikator.class)))
-        .thenReturn(new HttpStatusResponse<>(HttpStatus.I_AM_A_TEAPOT));
+        .thenReturn(HttpResponse.from(HttpStatus.I_AM_A_TEAPOT));
 
     var response = securedTestRestTemplate.exchange(
         "http://localhost:" + port + "/bidrag-dokument/journal/BID-123?saksnummer=777",
@@ -93,7 +93,8 @@ class EnhetFilterFilterTest {
   @DisplayName("skal logge requests mot applikasjonen som ikke inneholder enhetsinformasjon i header")
   void skalLoggeRequestsMotApplikasjonenMedHeaderInformasjon() {
     when(journalpostServiceMock.hentJournalpost(anyString(), any(KildesystemIdenfikator.class)))
-        .thenReturn(new HttpStatusResponse<>(HttpStatus.I_AM_A_TEAPOT));
+        .thenReturn(HttpResponse.from(HttpStatus.I_AM_A_TEAPOT));
+
     var enhet = "4802";
     var htpEntity = new HttpEntity<Void>(null, createEnhetHeader(enhet));
     var response = securedTestRestTemplate.exchange(

--- a/src/test/java/no/nav/bidrag/dokument/consumer/BidragArkivConsumerTest.java
+++ b/src/test/java/no/nav/bidrag/dokument/consumer/BidragArkivConsumerTest.java
@@ -41,8 +41,8 @@ class BidragArkivConsumerTest {
     when(restTemplateMock.exchange(anyString(), eq(HttpMethod.GET), any(), eq(JournalpostResponse.class)))
         .thenReturn(new ResponseEntity<>(enJournalpostMedJournaltilstand("ENDELIG"), HttpStatus.OK));
 
-    var httpStatuzResponse = bidragArkivConsumer.hentJournalpost("69","BID-101");
-    var journalpostResponse = httpStatuzResponse.fetchOptionalResult()
+    var httpResponse = bidragArkivConsumer.hentJournalpost("69","BID-101");
+    var journalpostResponse = httpResponse.fetchBody()
         .orElseThrow(() -> new AssertionError("BidragArkivConsumer kunne ikke finne journalpost!"));
 
     assertThat(journalpostResponse.getJournalpost()).extracting(JournalpostDto::getInnhold).isEqualTo("ENDELIG");

--- a/src/test/java/no/nav/bidrag/dokument/controller/JournalpostControllerTest.java
+++ b/src/test/java/no/nav/bidrag/dokument/controller/JournalpostControllerTest.java
@@ -186,6 +186,29 @@ class JournalpostControllerTest {
           () -> verify(restTemplateMock).exchange(eq("/journal/bid-1"), eq(HttpMethod.PUT), any(), eq(Void.class))
       ));
     }
+
+    @Test
+    @DisplayName("skal videresende headere når journalpost endres")
+    void skalVideresendeHeadereVedEndreJournalpost() {
+      var advarselHeader = new HttpHeaders();
+      advarselHeader.add(HttpHeaders.WARNING, "rofl");
+
+      when(restTemplateMock.exchange(anyString(), eq(HttpMethod.PUT), any(), eq(Void.class)))
+          .thenReturn(new ResponseEntity<>(advarselHeader, HttpStatus.BAD_REQUEST));
+
+      var lagreJournalpostUrl = initEndpointUrl("/journal/bid-1");
+      var endretJournalpostResponse = httpHeaderTestRestTemplate.exchange(
+          lagreJournalpostUrl, HttpMethod.PUT, new HttpEntity<>(new EndreJournalpostCommand(), createEnhetHeader("4802")), Void.class
+      );
+
+      assertThat(optional(endretJournalpostResponse)).hasValueSatisfying(response -> assertAll(
+          () -> assertThat(response.getStatusCode()).as("status").isEqualTo(HttpStatus.BAD_REQUEST),
+          () -> {
+            var headers = response.getHeaders();
+            assertThat(headers.getFirst(HttpHeaders.WARNING)).as("warning header").isEqualTo("rofl");
+          }
+      ));
+    }
   }
 
   @Nested

--- a/src/test/java/no/nav/bidrag/dokument/service/JournalpostServiceTest.java
+++ b/src/test/java/no/nav/bidrag/dokument/service/JournalpostServiceTest.java
@@ -3,13 +3,12 @@ package no.nav.bidrag.dokument.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import no.nav.bidrag.commons.KildesystemIdenfikator;
-import no.nav.bidrag.commons.web.HttpStatusResponse;
+import no.nav.bidrag.commons.web.HttpResponse;
 import no.nav.bidrag.dokument.consumer.BidragArkivConsumer;
 import no.nav.bidrag.dokument.consumer.BidragJournalpostConsumer;
 import no.nav.bidrag.dokument.dto.JournalpostDto;
@@ -36,20 +35,19 @@ class JournalpostServiceTest {
   @Test
   @DisplayName("skal ikke hente journalpost")
   void skalIkkeHenteJournalpostGittId() {
-    when(bidragArkivConsumerMock.hentJournalpost(anyString(), anyString())).thenReturn(new HttpStatusResponse<>(HttpStatus.NO_CONTENT));
+    when(bidragArkivConsumerMock.hentJournalpost(anyString(), anyString())).thenReturn(HttpResponse.from(HttpStatus.NO_CONTENT));
 
     var httpStatusResponse = journalpostService.hentJournalpost("69", new KildesystemIdenfikator("joark-2"));
-    assertThat(httpStatusResponse.fetchOptionalResult()).isNotPresent();
+    assertThat(httpStatusResponse.fetchBody()).isNotPresent();
   }
 
   @Test
   @DisplayName("skal hente journalpost gitt id")
   void skalHenteJournalpostGittId() {
-    when(bidragArkivConsumerMock.hentJournalpost(anyString(), anyString()))
-        .thenReturn(new HttpStatusResponse<>(HttpStatus.OK, new JournalpostResponse()));
+    when(bidragArkivConsumerMock.hentJournalpost(anyString(), anyString())).thenReturn(HttpResponse.from(HttpStatus.OK, new JournalpostResponse()));
 
     var httpStatusResponse = journalpostService.hentJournalpost("69", new KildesystemIdenfikator("joark-3"));
-    assertThat(httpStatusResponse.fetchOptionalResult()).isPresent();
+    assertThat(httpStatusResponse.fetchBody()).isPresent();
   }
 
   @Test


### PR DESCRIPTION
- bump bidrag-commons
- bruk av HttpResponse i steden for HttpStatusResponse
- når response blir returnert direkte, så legges header i response