### PR TITLE
Legge til exception-mapping for JwtTokenUnauthorizedException

### DIFF
--- a/src/main/java/no/nav/bidrag/dokument/aop/BidragDokumentRestControllerAdvice.java
+++ b/src/main/java/no/nav/bidrag/dokument/aop/BidragDokumentRestControllerAdvice.java
@@ -1,21 +1,49 @@
 package no.nav.bidrag.dokument.aop;
 
+import static no.nav.bidrag.commons.web.WebUtil.initHttpHeadersWith;
+
+import no.nav.bidrag.commons.ExceptionLogger;
+import no.nav.security.token.support.spring.validation.interceptor.JwtTokenUnauthorizedException;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice
-public class BidragDokumentRestControllerAdvice {
+public class BidragDokumentRestControllerAdvice extends ResponseEntityExceptionHandler {
+
+  private final ExceptionLogger exceptionLogger;
+
+  public BidragDokumentRestControllerAdvice(ExceptionLogger exceptionLogger) {
+    this.exceptionLogger = exceptionLogger;
+  }
 
   @ResponseBody
   @ExceptionHandler
-  public ResponseEntity<?> handleHttClientErrorException(HttpClientErrorException httpClientErrorException) {
-    return ResponseEntity
-        .status(httpClientErrorException.getStatusCode())
+  public ResponseEntity<?> handleHttClientErrorException(
+      HttpClientErrorException httpClientErrorException) {
+    return ResponseEntity.status(httpClientErrorException.getStatusCode())
         .header(HttpHeaders.WARNING, "Http client says: " + httpClientErrorException.getMessage())
         .build();
+  }
+
+  @ExceptionHandler(value = JwtTokenUnauthorizedException.class)
+  protected ResponseEntity<Object> handeUnauthorized(
+      final JwtTokenUnauthorizedException ex, final WebRequest request) {
+    var message = "Ugyldig sikkerhetstoken";
+
+    exceptionLogger.logException(ex, "RestResponseEntityExceptionHandler");
+
+    return handleExceptionInternal(
+        ex,
+        message,
+        initHttpHeadersWith(HttpHeaders.WARNING, message),
+        HttpStatus.UNAUTHORIZED,
+        request);
   }
 }

--- a/src/test/java/no/nav/bidrag/dokument/controller/DokumentControllerTest.java
+++ b/src/test/java/no/nav/bidrag/dokument/controller/DokumentControllerTest.java
@@ -4,6 +4,7 @@ import static no.nav.bidrag.dokument.BidragDokumentLocal.SECURE_TEST_PROFILE;
 import static no.nav.bidrag.dokument.BidragDokumentLocal.TEST_PROFILE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -54,6 +56,17 @@ class DokumentControllerTest {
         () -> assertThat(response).extracting(ResponseEntity::getBody).as("url")
             .isEqualTo(new DokumentTilgangResponse("urlWithToken", "BREVLAGER")))
     );
+  }
+
+  @Test
+  @DisplayName("Skal git status 401 dersom token mangler")
+  void skalGiStatus401DersomTokenMangler() {
+
+    var testRestTemplate = new TestRestTemplate();
+
+    var responseEntity = testRestTemplate.exchange(localhostUrl("/bidrag-dokument/tilgang/BID-123/dokref"), HttpMethod.GET, null, String.class);
+
+    assertEquals(responseEntity.getStatusCode(), HttpStatus.UNAUTHORIZED);
   }
 
   private String localhostUrl(@SuppressWarnings("SameParameterValue") String url) {

--- a/src/test/java/no/nav/bidrag/dokument/controller/JournalpostControllerTest.java
+++ b/src/test/java/no/nav/bidrag/dokument/controller/JournalpostControllerTest.java
@@ -280,14 +280,14 @@ class JournalpostControllerTest {
     }
 
     @Test
-    @DisplayName("skal få not implemented uten header value")
+    @DisplayName("skal få bad request uten header value")
     void skalFaBadRequestUtenHeaderValue() {
       final var avvikshendelse = new Avvikshendelse("BESTILL_ORIGINAL", "4806", "1001");
       var ukjentAvvikEntity = initHttpEntity(avvikshendelse);
       var url = initEndpointUrl("/journal/BID-1/avvik");
       var responseEntity = httpHeaderTestRestTemplate.exchange(url, HttpMethod.POST, ukjentAvvikEntity, OpprettAvvikshendelseResponse.class);
 
-      assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+      assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test

--- a/src/test/java/no/nav/bidrag/dokument/controller/JournalpostControllerTest.java
+++ b/src/test/java/no/nav/bidrag/dokument/controller/JournalpostControllerTest.java
@@ -8,6 +8,7 @@ import static no.nav.bidrag.dokument.BidragDokumentLocal.TEST_PROFILE;
 import static no.nav.bidrag.dokument.consumer.BidragJournalpostConsumer.createEnhetHeader;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -35,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
@@ -99,6 +101,18 @@ class JournalpostControllerTest {
               () -> verify(restTemplateMock).exchange(eq("/journal/JOARK-2?saksnummer=007"), eq(HttpMethod.GET), any(), eq(JournalpostResponse.class))
           )
       );
+    }
+
+    @Test
+    @DisplayName("Skal gi status 401 dersom token mangler")
+    void skalGiStatus401DersomTokenMangler() {
+
+      var testRestTemplate = new TestRestTemplate();
+
+      var url = initEndpointUrl("/journal/joark-2?saksnummer=007");
+      var responseEntity = testRestTemplate.exchange(url, HttpMethod.GET, null, String.class);
+
+      assertEquals(responseEntity.getStatusCode(), HttpStatus.UNAUTHORIZED);
     }
 
     private JournalpostResponse enJournalpostMedInnhold(@SuppressWarnings("SameParameterValue") String innhold) {


### PR DESCRIPTION
Manglende eller ugyldig token skal gi http status 401. Lagt til enhetstest for dokument- og journalpostcontroller.